### PR TITLE
Fix calling award.date

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -256,7 +256,7 @@
 			{{/if}}
 			{{#if date}}
 			<div class="date">
-				{{date}}
+				{{date date}}
 			</div>
 			{{/if}}
 			{{#if awarder}}


### PR DESCRIPTION
I'm loving this theme ❤️ 

This PR fixes not working `date` of `award`.

![image](https://user-images.githubusercontent.com/85887/27008384-6d191b94-4e24-11e7-8380-7c03b135e6c9.png)
