### PR TITLE
Fix insecure content warning when hosted over https

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -14,7 +14,7 @@
 		body { font-size: 12px; }
 	</style>
 
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300' rel='stylesheet' type='text/css'>
 	
 	</head>
 	<body>


### PR DESCRIPTION
If you host the HTML output of this theme over https protocol, you'll receive an insecure content warning and Google Fonts will fail to load. This change fixes that by updating the protocol for the `link` `href` attribute from `http://` to `https://`.